### PR TITLE
Add PageUp binding.

### DIFF
--- a/src/writer.rs
+++ b/src/writer.rs
@@ -91,6 +91,7 @@ fn default_keymap() -> AHashMap<KeyEvent, KeyBehavior> {
             (KeyCode::Char('k'), KeyBehavior::Up),
 
             (KeyCode::PageDown, KeyBehavior::PageDown),
+            (KeyCode::PageUp, KeyBehavior::PageUp),
 
             (KeyCode::Esc, KeyBehavior::NormalMode),
             (KeyCode::Home, KeyBehavior::GotoTop),


### PR DESCRIPTION
This change adds a binding to use the PAGE_UP key to scroll up an entire viewport page.
