### PR TITLE
Fix unnecessary redraws with scrolling.

### DIFF
--- a/src/writer.rs
+++ b/src/writer.rs
@@ -289,9 +289,12 @@ impl<'b> UiContext<'b> {
     }
 
     fn goto_scroll(&mut self, idx: usize) {
-        self.scroll = idx.min(self.max_scroll());
-        self.need_redraw = true;
-        self.prompt_outdated = true;
+        let new_scroll = idx.min(self.max_scroll());
+        if new_scroll != self.scroll {
+            self.scroll = new_scroll;
+            self.need_redraw = true;
+            self.prompt_outdated = true;
+        }
     }
 
     fn scroll_down(&mut self, idx: usize) {


### PR DESCRIPTION
This fix prevents unnecessary redraws and improves the experience when scrolling.

Prior to this fix, whenever you used a fast scroll wheel (e.g. trackpad scrolling) and scrolled above the beginning or past the end, `rp` would unnecessarily redraw the screen with every scroll event received. This would often result in waiting 15 seconds for `rp` to catch up to the stream of incoming events.