### PR TITLE
Only redraw after bulk input events.

### DIFF
--- a/src/writer.rs
+++ b/src/writer.rs
@@ -534,8 +534,6 @@ impl<'b> UiContext<'b> {
                 if self.handle_event(e)? {
                     return Ok(());
                 }
-
-                self.redraw()?;
             }
 
             let mut line_count = 0;


### PR DESCRIPTION
This fixes the slowdown that occurs when scrolling with a trackpad.
Closes #6.
